### PR TITLE
Adding PDF export and new Material theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 site/*
+__pycache__/**

--- a/README.md
+++ b/README.md
@@ -1,9 +1,43 @@
 # jardoc
 Public JARVICE documentation
 
-# Test
+# Local test the documentation
+
+From the toplevel directory of this repo
+
 ```
-# from toplevel directory of this repo
+pip install -r requirements.txt
+mkdocs serve
+```
+Local changes to markdown files automatically reload in test server.
+
+# Generate PDF documentation
+
+* Uncomment the `with-pdf` part from the `mkdocs.yml` configuration file.
+
+```
+plugins:
+# - with-pdf:
+    #     author: Nimbix
+    #     copyright: '@ 2022 Nimbix'
+    #     cover: true
+    #     back_cover: false
+    #     cover_title: Jarvice
+    #     cover_subtitle: documentation
+    #     toc_level: 2
+    #     output_path: pdf/jarvice.pdf
+```
+
+* Install the following packages with your package manager
+
+```
+libpangoft2-1.0-0
+libpango-1.0-0
+```
+
+* From the toplevel directory of this repo
+
+```
 pip install -r requirements.txt
 mkdocs serve
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Public JARVICE documentation
 # Test
 ```
 # from toplevel directory of this repo
-pip install mkdocs
+pip install -r requirements.txt
 mkdocs serve
 ```
 Local changes to markdown files automatically reload in test server.

--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -1,3 +1,18 @@
+@page {
+    size: a4 portrait;
+    margin: 25mm 10mm 25mm 10mm;
+    counter-increment: page;
+    font-family: "Roboto","Helvetica Neue",Helvetica,Arial,sans-serif;
+    white-space: pre;
+    color: grey;
+    @top-left {
+        content: '©2021 Nimbix';
+    }
+    @top-center {
+        content: string(chapter);
+    }
+}
+
 @font-face {
     font-family: 'Roboto';
     font-style: normal;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,20 +1,19 @@
 site_name: JARVICE
-#theme: readthedocs
 theme:
   name: material
   features:
     - navigation.instant
 plugins:
     - search
-    - with-pdf:
-        author: Nimbix
-        copyright: '@ 2022 Nimbix'
-        cover: true
-        back_cover: false
-        cover_title: Jarvice
-        cover_subtitle: documentation
-        toc_level: 2
-        output_path: pdf/jarvice.pdf
+    # - with-pdf:
+    #     author: Nimbix
+    #     copyright: '@2021 Nimbix'
+    #     cover: true
+    #     back_cover: false
+    #     cover_title: Jarvice
+    #     cover_subtitle: documentation
+    #     toc_level: 2
+    #     output_path: pdf/jarvice.pdf
 extra_css:
     - css/extra.css
 nav:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,20 @@
 site_name: JARVICE
-theme: readthedocs
+#theme: readthedocs
+theme:
+  name: material
+  features:
+    - navigation.instant
+plugins:
+    - search
+    - with-pdf:
+        author: Nimbix
+        copyright: '@ 2022 Nimbix'
+        cover: true
+        back_cover: false
+        cover_title: Jarvice
+        cover_subtitle: documentation
+        toc_level: 2
+        output_path: pdf/jarvice.pdf
 extra_css:
     - css/extra.css
 nav:

--- a/pdf_event_hook.py
+++ b/pdf_event_hook.py
@@ -1,0 +1,53 @@
+import logging
+
+from bs4 import BeautifulSoup
+from mkdocs.structure.pages import Page
+
+
+def inject_link(html: str, href: str,
+                page: Page, logger: logging) -> str:
+    """Adding PDF View button on navigation bar(using material theme)"""
+
+    def _pdf_icon():
+        _ICON = '''
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+<path d="M128,0c-17.6,0-32,14.4-32,32v448c0,17.6,14.4,32,32,32h320c17.6,0,32-14.4,32-32V128L352,0H128z" fill="#E2E5E7"/>
+<path d="m384 128h96l-128-128v96c0 17.6 14.4 32 32 32z" fill="#B0B7BD"/>
+<polygon points="480 224 384 128 480 128" fill="#CAD1D8"/>
+<path d="M416,416c0,8.8-7.2,16-16,16H48c-8.8,0-16-7.2-16-16V256c0-8.8,7.2-16,16-16h352c8.8,0,16,7.2,16,16  V416z" fill="#F15642"/>
+<g fill="#fff">
+<path d="m101.74 303.15c0-4.224 3.328-8.832 8.688-8.832h29.552c16.64 0 31.616 11.136 31.616 32.48 0 20.224-14.976 31.488-31.616 31.488h-21.36v16.896c0 5.632-3.584 8.816-8.192 8.816-4.224 0-8.688-3.184-8.688-8.816v-72.032zm16.88 7.28v31.872h21.36c8.576 0 15.36-7.568 15.36-15.504 0-8.944-6.784-16.368-15.36-16.368h-21.36z"/>
+<path d="m196.66 384c-4.224 0-8.832-2.304-8.832-7.92v-72.672c0-4.592 4.608-7.936 8.832-7.936h29.296c58.464 0 57.184 88.528 1.152 88.528h-30.448zm8.064-72.912v57.312h21.232c34.544 0 36.08-57.312 0-57.312h-21.232z"/>
+<path d="m303.87 312.11v20.336h32.624c4.608 0 9.216 4.608 9.216 9.072 0 4.224-4.608 7.68-9.216 7.68h-32.624v26.864c0 4.48-3.184 7.92-7.664 7.92-5.632 0-9.072-3.44-9.072-7.92v-72.672c0-4.592 3.456-7.936 9.072-7.936h44.912c5.632 0 8.96 3.344 8.96 7.936 0 4.096-3.328 8.704-8.96 8.704h-37.248v0.016z"/>
+</g>
+<path d="m400 432h-304v16h304c8.8 0 16-7.2 16-16v-16c0 8.8-7.2 16-16 16z" fill="#CAD1D8"/>
+</svg>
+'''  # noqa: E501
+        return BeautifulSoup(_ICON, 'html.parser')
+
+    logger.info(f'(hook on inject_link: {page.title})')
+    soup = BeautifulSoup(html, 'html.parser')
+
+    nav = soup.find(class_='md-header__topic')
+    if nav:
+        a = soup.new_tag('a', style='position: relative', href="/pdf/jarvice.pdf", title='PDF',
+                         **{'class': 'md-header__topic md-header__button md-icon'})
+        a.append(_pdf_icon())
+        nav.append(a)
+        return str(soup)
+
+    return html
+
+
+# def pre_js_render(soup: BeautifulSoup, logger: logging) -> BeautifulSoup:
+#     logger.info('(hook on pre_js_render)')
+#     return soup
+
+
+# def pre_pdf_render(soup: BeautifulSoup, logger: logging) -> BeautifulSoup:
+#     logger.info('(hook on pre_pdf_render)')
+#     tag = soup.find(lambda tag: tag.name ==
+#                     'body' and 'data-md-color-scheme' in tag.attrs)
+#     if tag:
+#         tag['data-md-color-scheme'] = 'print'
+#     return soup

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 mkdocs==1.3.0
+mkdocs-material==9.0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 mkdocs==1.3.0
 mkdocs-material==9.0.5
+mkdocs-with-pdf==0.9.3


### PR DESCRIPTION
Solving feature #14 .

Note, a few warning which are not coming from this PR should be solved I think:
```
INFO     -  The following pages exist in the docs directory, but are not included in the "nav" configuration:
              - ptc_overview.md
              - ptc_tutorial.md
              - ptc_workflow.md
              - ptc_workflows.md
WARNING  -  Documentation file 'ptc_workflow.md' contains a link to 'img/BuildinganddeployingWorkflows.png' which is not found in the
            documentation files.
WARNING  -  Documentation file 'ptc_workflows.md' contains a link to 'Building and deploying Workflows.png' which is not found in the
            documentation files.
WARNING  -  Documentation file 'ptc_workflows.md' contains a link to 'Nimbix images/note.png' which is not found in the documentation
            files.
WARNING  -  Documentation file 'ptc_workflows.md' contains a link to 'Nimbix images/PUSHtoComputeCreate.png' which is not found in the
            documentation files.
WARNING  -  Documentation file 'ptc_workflows.md' contains a link to '../Desktop/note.png' which is not found in the documentation
            files.
WARNING  -  Documentation file 'ptc_workflows.md' contains a link to 'blue line.png' which is not found in the documentation files.
WARNING  -  Documentation file 'ptc_workflows.md' contains a link to 'Nimbix images/techsupport.png' which is not found in the
            documentation files.
```
